### PR TITLE
expose kdc to host and make it compatible with default JAAS for Java …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       # This is needed otherwise there won't be enough entropy to generate a new kerberos realm
       - /dev/urandom:/dev/random
+    ports:
+      - "88:88/udp"
 
   kerberos-client:
     build: ./kerberos-client

--- a/kerberos.env
+++ b/kerberos.env
@@ -1,4 +1,4 @@
 REALM=EXAMPLE.COM
-SUPPORTED_ENCRYPTION_TYPES=aes256-cts-hmac-sha1-96:normal
+SUPPORTED_ENCRYPTION_TYPES=aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal des3-cbc-sha1:normal arcfour-hmac-md5:normal
 KADMIN_PRINCIPAL=kadmin/admin
 KADMIN_PASSWORD=MITiys4K5


### PR DESCRIPTION
expose kdc to the host and make it compatible with default JAAS kerberos module for Java 1.8 clients (tested on linux)